### PR TITLE
긴급 다이얼 목록 자동 동기화

### DIFF
--- a/app/src/main/java/com/example/plandial/MainActivity.java
+++ b/app/src/main/java/com/example/plandial/MainActivity.java
@@ -13,8 +13,12 @@ import android.widget.ImageView;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Timer;
+import java.util.TimerTask;
 
 public class MainActivity extends AppCompatActivity {
+
+    private static final int SYNCING_URGENT_PERIOD = 1 * 60 * 1000; // 단위: ms
 
     SpinnableDialView mainDialSlider;
     ConstraintLayout mainDialLayout;
@@ -82,6 +86,16 @@ public class MainActivity extends AppCompatActivity {
             mainDialSlider.setCategoryDialAdapter(gridAdapter);
 
             gridAdapter.setStatusDisplayLayout(statusDisplayLayout);
+
+            // urgent dial 주기적 동기화
+            TimerTask syncUrgentTask = new TimerTask() {
+                @Override
+                public void run() {
+                    adapter.syncDials();
+                }
+            };
+            Timer timer = new Timer();
+            timer.schedule(syncUrgentTask, 0, SYNCING_URGENT_PERIOD);
         }
 
     }


### PR DESCRIPTION
TimerTask와 Timer를 사용하여 메인 페이지의 긴급 다이얼 목록이 주기적(임의로 1분 간격으로 설정함)으로 동기화될 수 있도록 함.
해당 기능은 앱이 켜진 상태에서만 작동하면 되는 기능이고, 푸시 알림은 그렇지 않으므로 각기 다른 방법을 이용하였음.

주기적으로 전체 다이얼 중 긴급한 다이얼을 뽑아내는 것이 비효율적일 수 있으나, 우선 원활한 업무 진행을 위해 병합을 요청함.