### PR TITLE
다이얼 수정 페이지에 시작일 추가 (프리셋 대응)

### DIFF
--- a/app/src/main/java/com/example/plandial/AlertDial.java
+++ b/app/src/main/java/com/example/plandial/AlertDial.java
@@ -77,7 +77,7 @@ public class AlertDial extends Dial {
             int times = (int) (minus / getPeriod().getPeriodInMillis()) + 1;
             return getPeriod().getPeriodInMillis() * times - minus;
         } else {
-            return startInMillis;
+            return startInMillis - nowInMillis;
         }
     }
 

--- a/app/src/main/java/com/example/plandial/DateTimePickerDialog.java
+++ b/app/src/main/java/com/example/plandial/DateTimePickerDialog.java
@@ -1,5 +1,6 @@
 package com.example.plandial;
 
+import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
@@ -9,17 +10,17 @@ import android.widget.TimePicker;
 import java.time.OffsetDateTime;
 
 public class DateTimePickerDialog {
-    private OffsetDateTime selectedDateTime = OffsetDateTime.now();
+    private OffsetDateTime selectedDateTime;
 
     private final DatePickerDialog datePickerDialog;
     private final TimePickerDialog timePickerDialog;
 
-    public DateTimePickerDialog(Context context, IOffsetDateTimeRequester offsetDateTimeRequester) {
+    public DateTimePickerDialog(Context context, IOffsetDateTimeRequester offsetDateTimeRequester, OffsetDateTime originalDateTime) {
 
         DatePickerDialog.OnDateSetListener datePickerCallbackMethod = new DatePickerDialog.OnDateSetListener() {
             @Override
             public void onDateSet(DatePicker datePicker, int year, int month, int dayOfMonth) {
-                selectedDateTime = selectedDateTime.withYear(year).withMonth(month + 1).withDayOfMonth(dayOfMonth);
+                selectedDateTime = originalDateTime.withYear(year).withMonth(month + 1).withDayOfMonth(dayOfMonth);
 
                 // TimePickerDialog를 연달아 호출함
                 timePickerDialog.show();
@@ -47,7 +48,11 @@ public class DateTimePickerDialog {
                 timePickerCallbackMethod,
                 OffsetDateTime.now().getHour(),
                 OffsetDateTime.now().getMinute(),
-                true);
+                false);
+    }
+
+    public DateTimePickerDialog(Activity activity, DateTimeTextView startDayInput) {
+        this(activity, startDayInput, OffsetDateTime.now());
     }
 
     public void show() {

--- a/app/src/main/java/com/example/plandial/DateTimeTextView.java
+++ b/app/src/main/java/com/example/plandial/DateTimeTextView.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.IllegalFormatException;
+import java.util.Locale;
 
-public class DateTimeTextView extends FormatTextView implements IOffsetDateTimeRequester{
+public class DateTimeTextView extends FormatTextView implements IOffsetDateTimeRequester {
 
     private OffsetDateTime dateTime;
 
@@ -27,10 +29,14 @@ public class DateTimeTextView extends FormatTextView implements IOffsetDateTimeR
         int hour = offsetDateTime.getHour();
         int minute = offsetDateTime.getMinute();
 
+        String weekOfDay = offsetDateTime.format(DateTimeFormatter.ofPattern("E"));
+        int hour12 = hour == 12 ? 12 : hour % 12;
+        String amPm = offsetDateTime.getHour() < 12 ? "오전" : "오후";
+
         try {
-            this.setText(String.format(formatString, year, month, day, hour, minute));
+            this.setText(String.format(formatString, year, month, day, weekOfDay, amPm, hour12, minute));
         } catch (IllegalFormatException | NullPointerException exception) {
-            this.setText(String.format("%d %d %d %d %d", year, month, day, hour, minute));
+            this.setText(String.format(Locale.KOREA, "%d %d %d %d %d", year, month, day, hour, minute));
             assert (false);
             return false;
         }

--- a/app/src/main/java/com/example/plandial/DialEditingViewModel.java
+++ b/app/src/main/java/com/example/plandial/DialEditingViewModel.java
@@ -13,6 +13,8 @@ import androidx.annotation.RequiresApi;
 import com.example.plandial.db.WorkDatabase;
 import com.example.plandial.policy.EditDialValidator;
 
+import java.time.OffsetDateTime;
+
 public class DialEditingViewModel implements ISettingViewModel {
     private static final String FORMAT_STRING = "선택하신 내용대로 %s 다이얼을 수정할게요!";
     private static final EditDialValidator dialValidator = new EditDialValidator();
@@ -25,10 +27,12 @@ public class DialEditingViewModel implements ISettingViewModel {
     private final EditText dialNameView;
     private final Switch unableSwitchView;
     private final CheckBox iconCheckbox;
+    private final DateTimeTextView startDayView;
 
     private String dialNameData;
     private Period periodData;
     private boolean unableData;
+    private OffsetDateTime startDayData;
 
     public DialEditingViewModel(Activity activity, AlertDial dial, Category category) {
         this.activity = activity;
@@ -40,6 +44,7 @@ public class DialEditingViewModel implements ISettingViewModel {
         this.unitOfTime = activity.findViewById(R.id.DialTime_UnitOfTime);
         this.unableSwitchView = activity.findViewById(R.id.switchButton);
         this.iconCheckbox = activity.findViewById(R.id.Icon_Checkbox);
+        this.startDayView = activity.findViewById(R.id.Input_Startday);
     }
 
     @Override
@@ -52,6 +57,7 @@ public class DialEditingViewModel implements ISettingViewModel {
         this.dialNameData = dialNameView.getText().toString();
         this.periodData = new Period(unit, Integer.parseInt(period.getText().toString()));
         this.unableData = unableSwitchView.isChecked();
+        this.startDayData = startDayView.getDateTime();
         //endregion
 
         //region 값이 유효한 지 판단함
@@ -73,6 +79,9 @@ public class DialEditingViewModel implements ISettingViewModel {
                 builder.setMessage("주기는 0보다 커야 합니다.");
                 builder.show();
                 return false;
+            } else if (!dialValidator.validateStartDay(startDayData)) {
+                builder.setMessage("시작일이 유효하지 않습니다.");
+                builder.show();
             }
         }
         //endregion
@@ -100,6 +109,7 @@ public class DialEditingViewModel implements ISettingViewModel {
         // 다이얼 수정
         dial.setName(activity.getApplicationContext(), dialNameData, iconCheckbox.isChecked());
         dial.setPeriod(periodData);
+        dial.setStartDateTime(startDayData);
 
         if (unableData) {
             dial.disable(activity.getApplicationContext());

--- a/app/src/main/java/com/example/plandial/DialSettingViewModel.java
+++ b/app/src/main/java/com/example/plandial/DialSettingViewModel.java
@@ -2,7 +2,6 @@ package com.example.plandial;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.os.Build;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -11,7 +10,6 @@ import androidx.annotation.RequiresApi;
 
 import com.example.plandial.db.WorkDatabase;
 import com.example.plandial.policy.BasicDialValidator;
-import com.example.plandial.policy.IDialValidator;
 
 import java.time.OffsetDateTime;
 
@@ -73,7 +71,6 @@ public class DialSettingViewModel implements ISettingViewModel {
                 builder.show();
                 return false;
             } else if (!dialValidator.validateStartDay(startDayData)) {
-                // 시작일이 과거면 현재로 강제 이동
                 this.startDayData = OffsetDateTime.now();
                 startDayView.setByOffsetDateTime(startDayData);
             }

--- a/app/src/main/java/com/example/plandial/EditDialActivity.java
+++ b/app/src/main/java/com/example/plandial/EditDialActivity.java
@@ -34,6 +34,7 @@ public class EditDialActivity extends AppCompatActivity implements TextView.OnEd
     private Category category;
     private AlertDial dial;
 
+    private DateTimeTextView startDayInput;
     private EditText Input_DialName;
     private ImageButton backButton;
     private ImageButton removeButton;
@@ -120,6 +121,15 @@ public class EditDialActivity extends AppCompatActivity implements TextView.OnEd
             completeButton.setOnClickListener(view -> dialEditingViewModel.complete());
         }
         //endregion
+
+        {
+            startDayInput = findViewById(R.id.Input_Startday);
+            startDayInput.setByOffsetDateTime(dial.getStartDateTime());
+            startDayInput.setOnClickListener(view -> {
+                DateTimePickerDialog dateTimePickerDialog = new DateTimePickerDialog(this, startDayInput, dial.getStartDateTime());
+                dateTimePickerDialog.show();
+            });
+        }
 
 
         periodPlus.setOnLongClickListener(v -> {

--- a/app/src/main/java/com/example/plandial/EditDialActivity.java
+++ b/app/src/main/java/com/example/plandial/EditDialActivity.java
@@ -75,7 +75,7 @@ public class EditDialActivity extends AppCompatActivity implements TextView.OnEd
             iconCheckbox = findViewById(R.id.Icon_Checkbox);
 
             Input_DialName.setText(dial.getName());
-            iconImage.setImageResource(dial.getIcon());
+            iconImage.setImageResource(new IconRecommendation().getIconByName(this, dial.getName()));
 
             countForPeriod = dial.getPeriod().getTimes();
             countForUnitOfTime = (int) UnitOfTime.unitToIndex.get(dial.getPeriod().getUnit());

--- a/app/src/main/java/com/example/plandial/policy/BasicDialValidator.java
+++ b/app/src/main/java/com/example/plandial/policy/BasicDialValidator.java
@@ -25,6 +25,6 @@ public class BasicDialValidator implements IDialValidator {
 
     @Override
     public boolean validateStartDay(OffsetDateTime startDay) {
-        return startDay != null && startDay.isAfter(OffsetDateTime.now());
+        return startDay != null;
     }
 }

--- a/app/src/main/java/com/example/plandial/policy/EditDialValidator.java
+++ b/app/src/main/java/com/example/plandial/policy/EditDialValidator.java
@@ -27,6 +27,6 @@ public class EditDialValidator implements IDialValidator {
 
     @Override
     public boolean validateStartDay(OffsetDateTime startDay) {
-        return startDay != null && startDay.isAfter(OffsetDateTime.now());
+        return startDay != null;
     }
 }

--- a/app/src/main/res/layout/activity_edit_dial.xml
+++ b/app/src/main/res/layout/activity_edit_dial.xml
@@ -192,26 +192,52 @@
         app:layout_constraintTop_toBottomOf="@id/DialTime_UnitOfTime" />
 
     <TextView
+        android:id="@+id/StartDay"
+        android:layout_width="70dp"
+        android:layout_height="23dp"
+        android:layout_marginStart="53dp"
+        android:layout_marginTop="3dp"
+        android:text="@string/Startday"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/Period_Down" />
+
+    <com.example.plandial.DateTimeTextView
+        android:id="@+id/Input_Startday"
+        android:layout_width="304dp"
+        android:layout_height="42dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/bg_namebox"
+        android:gravity="center"
+        android:textSize="20sp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/StartDay"
+        custom:formatString="%d.%d.%d(%s) %s %02d:%02d" />
+
+    <TextView
         android:id="@+id/InactivateDial"
         android:layout_width="140dp"
         android:layout_height="23dp"
         android:layout_marginStart="53dp"
-        android:layout_marginTop="60dp"
+        android:layout_marginTop="20dp"
         android:text="@string/InactivateDial"
         android:textColor="@color/black"
         android:textSize="18sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/DialTime_Period" />
+        app:layout_constraintTop_toBottomOf="@+id/Input_Startday" />
 
     <Switch
         android:id="@+id/switchButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="100dp"
-        android:layout_marginTop="60dp"
+        android:layout_marginTop="20dp"
         android:thumb="@drawable/switch_thumb_selector"
         android:track="@drawable/switch_track_selector"
         app:layout_constraintLeft_toRightOf="@id/InactivateDial"
-        app:layout_constraintTop_toBottomOf="@+id/DialTime_Period" />
+        app:layout_constraintTop_toBottomOf="@+id/Input_Startday" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_plus_dial.xml
+++ b/app/src/main/res/layout/activity_plus_dial.xml
@@ -182,7 +182,7 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/StartDay"
-        custom:formatString="%d.%d.%d %02d:%02d" />
+        custom:formatString="%d.%d.%d(%s) %s %02d:%02d" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/DialPlus_box"


### PR DESCRIPTION
현재 카테고리 생성시 개별 프리셋에 대한 시작일을 설정할 수 없는 상황입니다.
하지만 `아침 식사` 등 시작일 설정이 꼭 필요한 프리셋이 존재합니다.

따라서, 템플릿을 가져온 후 **직접 다이얼 수정 페이지에서 시작일을 수정할 수 있도록** 변경하였습니다.
확인 부탁드립니다 ^^7